### PR TITLE
Replaced backticks by single quotes

### DIFF
--- a/doc/news/20250123-gom-math.md
+++ b/doc/news/20250123-gom-math.md
@@ -1,4 +1,4 @@
-# Using the `gom_vec3d` and `gom_math` modules
+# Using the 'gom_vec3d' and 'gom_math' modules
 
 ```{eval-rst}
 .. feed-entry::


### PR DESCRIPTION
Backticks are not rendered correctly on the news page